### PR TITLE
Potential hotfixes for memory leak and null reference exception

### DIFF
--- a/domain-model-assistant/Assets/Components/Scripts/Diagram.cs
+++ b/domain-model-assistant/Assets/Components/Scripts/Diagram.cs
@@ -140,18 +140,18 @@ public class Diagram : MonoBehaviour
                 _updateNeeded = false;
                 req.Dispose();
             }
-            if (_postRequestAsyncOp != null && _postRequestAsyncOp.isDone)
-            {
-                _postRequestAsyncOp.webRequest.Dispose();
-            }
-            if (_deleteRequestAsyncOp != null && _deleteRequestAsyncOp.isDone)
-            {
-                _deleteRequestAsyncOp.webRequest.Dispose();
-            }
-            if (_putRequestAsyncOp != null && _putRequestAsyncOp.isDone)
-            {
-                _putRequestAsyncOp.webRequest.Dispose();
-            }
+        }
+        if (_postRequestAsyncOp != null && _postRequestAsyncOp.isDone)
+        {
+            _postRequestAsyncOp.webRequest.Dispose();
+        }
+        if (_deleteRequestAsyncOp != null && _deleteRequestAsyncOp.isDone)
+        {
+            _deleteRequestAsyncOp.webRequest.Dispose();
+        }
+        if (_putRequestAsyncOp != null && _putRequestAsyncOp.isDone)
+        {
+            _putRequestAsyncOp.webRequest.Dispose();
         }
     }
 
@@ -359,10 +359,17 @@ public class Diagram : MonoBehaviour
             }
             //get first section, loop through all attributes, destroy any attribute cross objects
             GameObject section = comp.GetComponent<CompartmentedRectangle>().GetSection(0);
-            foreach(var attr in section.GetComponent<Section>().GetTextBoxList()){
-                if(attr.GetComponent<TextBox>().GetAttributeCross() !=null){
-                    //TODO: Destroy instance instead
-                    attr.GetComponent<TextBox>().GetAttributeCross().GetComponent<AttributeCross>().Close();
+            foreach(var attr in section.GetComponent<Section>().GetTextBoxList())
+            {
+                if (attr)
+                {
+                    if (attr.GetComponent<TextBox>())
+                    {
+                        if (attr.GetComponent<TextBox>().GetAttributeCross() != null) {
+                            //TODO: Destroy instance instead
+                            attr.GetComponent<TextBox>().GetAttributeCross().GetComponent<AttributeCross>().Close();
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
I think I have solutions for two of the problems we are facing in #56:

* The memory leak stack trace only happens for the PUT request, which is of type `UnityWebRequest`. In the original code, the dispose call (`_putRequestAsyncOp.webRequest.Dispose();`) was not called at each frame update unless `_updateNeeded` was true, which led to the error. Moving the dispose calls outside the outer if statement should solve this problem.
* In `ResetDiagram()`, I would often get a null reference exception whenever I try to delete something (since it had already been disposed but remained in the diagram). To get rid of the exception, I changed this line

```cs
if (attr.GetComponent<TextBox>().GetAttributeCross() != null)
```

to

```cs
if (attr)
{
    if (attr.GetComponent<TextBox>())
    {
        if (attr.GetComponent<TextBox>().GetAttributeCross() != null)
```

I also tried the [null conditional (Elvis) operator `?.`](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/member-access-operators#null-conditional-operators--and-) to write this more concisely, but it didn't work in Unity for some reason 😕

```cs
if (attr?.GetComponent<TextBox>()?.GetAttributeCross() != null)
```

Please try out these fixes, and if they work for you, please merge this into the unity-frontend branch.