### PR TITLE
Fix for moving class and some cleanup #65

### DIFF
--- a/domain-model-assistant/Assets/Components/Prefabs/AttributeCross.prefab
+++ b/domain-model-assistant/Assets/Components/Prefabs/AttributeCross.prefab
@@ -19,7 +19,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &2013105332043614286
 RectTransform:
   m_ObjectHideFlags: 0

--- a/domain-model-assistant/Assets/Components/Prefabs/CompartmentedRectangle.prefab
+++ b/domain-model-assistant/Assets/Components/Prefabs/CompartmentedRectangle.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 4578845947496216861}
   - component: {fileID: 4578845947496216862}
   m_Layer: 5
-  m_Name: Header
+  m_Name: HeaderBackground
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -171,8 +171,10 @@ MonoBehaviour:
   textbox: {fileID: 5633685818171654614, guid: 1409969191897be419ff942e39640dff, type: 3}
   section: {fileID: 8699455690723162231, guid: 1396b8a5385e3cd4ca1b245b6b8891d1, type: 3}
   sections: []
+  text: {fileID: 0}
   popupMenu: {fileID: 8564540208968287839, guid: 9913a5b3d214e7642a24bee2f858e6e7,
     type: 3}
+  state: 0
 --- !u!114 &2934163152826966153
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/domain-model-assistant/Assets/Components/Prefabs/Textbox.prefab
+++ b/domain-model-assistant/Assets/Components/Prefabs/Textbox.prefab
@@ -14,6 +14,7 @@ GameObject:
   - component: {fileID: -2204039392561895175}
   - component: {fileID: 8079727894406178735}
   - component: {fileID: 6164206989483138962}
+  - component: {fileID: -7634711185766664062}
   m_Layer: 5
   m_Name: Textbox
   m_TagString: Untagged
@@ -37,9 +38,9 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -32.8, y: 40}
+  m_AnchoredPosition: {x: -112.8, y: 40}
   m_SizeDelta: {x: 160, y: 20}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &5633685818171654611
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -81,7 +82,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 1
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: Enter Text ...
+  m_Text: Class2
 --- !u!114 &-2204039392561895175
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -94,6 +95,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 41484c546806a8d47bcd64c32164fd90, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  text: {fileID: 0}
   sect: {fileID: 0}
   attribcross: {fileID: 3222643647847603311, guid: 16ef25d540df641169fa84b0e0c0763b,
     type: 3}
@@ -160,7 +162,7 @@ MonoBehaviour:
   m_CaretColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
   m_CustomCaretColor: 0
   m_SelectionColor: {r: 0.65882355, g: 0.80784315, b: 1, a: 0.7529412}
-  m_Text: Enter Text ...
+  m_Text: Class2
   m_CaretBlinkRate: 0.9
   m_CaretWidth: 2
   m_ReadOnly: 0
@@ -210,3 +212,17 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 0
           m_CallState: 2
+--- !u!114 &-7634711185766664062
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5633685818171654614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 2
+  m_VerticalFit: 2

--- a/domain-model-assistant/Assets/Components/Scripts/AttributeCross.cs
+++ b/domain-model-assistant/Assets/Components/Scripts/AttributeCross.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 public class AttributeCross : MonoBehaviour
 {
     GameObject textbox; 
-    public const int UpdatePositionConst = -100;
+    public const int UpdatePositionConst = -12;
 
     // Start is called before the first frame update
     void Start()

--- a/domain-model-assistant/Assets/Components/Scripts/CompartmentedRectangle.cs
+++ b/domain-model-assistant/Assets/Components/Scripts/CompartmentedRectangle.cs
@@ -6,31 +6,28 @@ using UnityEngine.UI;
 
 public class CompartmentedRectangle : Node
 {
-
     public GameObject textbox; //this allows to instantiate textbox prefabs
     public GameObject section;
     public List<GameObject> sections = new List<GameObject>();
-
     public TextBox text;
-
-    public bool isHighlighted
-    { get; set; }
-
     // popup menu variables
     public GameObject popupMenu;
     float holdTimer = 0;
     bool hold = false;
-
+    public State state = State.Default;
+    private Diagram _diagram;
+    private Vector2 _prevPosition;
+    private int headerOffsetX = -31;
+    private int headerOffsetY = 70;
+    private int sectionOffsetY = -71;
+    private int popupMenuOffsetX = 100;
+    public bool isHighlighted
+    { get; set; }
     public enum State
     {
         Default,
         DraggingClass,
     }
-
-    public State state = State.Default;
-    private Diagram _diagram;
-
-    private Vector2 _prevPosition;
 
     void Awake()
     {
@@ -64,20 +61,20 @@ public class CompartmentedRectangle : Node
     {
         var header = GameObject.Instantiate(textbox, this.transform);
         //vector position will need to be obtained from transform of gameobject in the future
-        header.transform.position = this.transform.position + new Vector3(0, 70, 0);
+        header.transform.position = this.transform.position + new Vector3(headerOffsetX, headerOffsetY, 0);
         AddHeader(header);
     }
 
     public void CreateSection()
     {
         Vector3 oldPosition = this.transform.position + new Vector3(0, 18, 0);
-        for (int i = 0; i < 2; i++)/*this loop assumes that class always has 2 sections*/
+        for (int i = 0; i < 2; i++)/*loop for a class with 2 sections*/
         {
             var sect = GameObject.Instantiate(section, this.transform);
-            sect.transform.position = oldPosition + new Vector3(0, -71, 0) * sections.Count;
+            sect.transform.position = oldPosition + new Vector3(0, sectionOffsetY, 0) * sections.Count;
             AddSection(sect);
-            _diagram.AddAttributes(GetSection(i), i);//add atrributes to section
         }
+        _diagram.AddAttributesToSection(GetSection(0));//add atrributes to first section
     }
 
     public void OnBeginHold()
@@ -89,7 +86,7 @@ public class CompartmentedRectangle : Node
 
     public void OnEndHold()
     {
-        if (holdTimer > 1f-5 && state == State.Default)
+        if (holdTimer > 1f - 5 && state == State.Default)
         {
             SpawnPopupMenu();
         }
@@ -105,7 +102,7 @@ public class CompartmentedRectangle : Node
         if (this.popupMenu.GetComponent<PopupMenu>().getCompartmentedRectangle() == null)
         {
             this.popupMenu = GameObject.Instantiate(this.popupMenu);
-            this.popupMenu.transform.position = this.transform.position + new Vector3(100, 0, 0);
+            this.popupMenu.transform.position = this.transform.position + new Vector3(popupMenuOffsetX, 0, 0);
             this.popupMenu.GetComponent<PopupMenu>().SetCompartmentedRectangle(this);
         }
         else
@@ -153,8 +150,19 @@ public class CompartmentedRectangle : Node
         return this.transform.position;
     }
 
-    public GameObject GetPopUpMenu(){
+    public GameObject GetPopUpMenu()
+    {
         return this.popupMenu;
+    }
+
+    public void SetState(State aState)
+    {
+        this.state = aState;
+    }
+
+    public State GetState()
+    {
+        return state;
     }
     // ************ END UI model Methods for Compartmented Rectangle ****************//
 

--- a/domain-model-assistant/Assets/Components/Scripts/MouseDragBehaviour.cs
+++ b/domain-model-assistant/Assets/Components/Scripts/MouseDragBehaviour.cs
@@ -15,15 +15,15 @@ public class MouseDragBehaviour : MonoBehaviour, IDragHandler, IBeginDragHandler
 
     public void OnDrag(PointerEventData eventData)
     {
-        this.gameObject.GetComponent<CompartmentedRectangle>().state = CompartmentedRectangle.State.DraggingClass;
+        GetComponent<CompartmentedRectangle>().SetState(CompartmentedRectangle.State.DraggingClass);
         Vector2 currentMousePosition = eventData.position;
         Vector2 diff = currentMousePosition - lastMousePosition;
         RectTransform rect = GetComponent<RectTransform>();
 
-        Vector3 newPosition = rect.position +  new Vector3(diff.x, diff.y, transform.position.z);
+        Vector3 newPosition = rect.position + new Vector3(diff.x, diff.y, transform.position.z);
         Vector3 oldPos = rect.position;
         rect.position = newPosition;
-        if(!IsRectTransformInsideSreen(rect))
+        if (!IsRectTransformInsideSreen(rect))
         {
             rect.position = oldPos;
         }
@@ -32,7 +32,7 @@ public class MouseDragBehaviour : MonoBehaviour, IDragHandler, IBeginDragHandler
 
     public void OnEndDrag(PointerEventData eventData)
     {
-        this.gameObject.GetComponent<CompartmentedRectangle>().state = CompartmentedRectangle.State.Default;
+        GetComponent<CompartmentedRectangle>().SetState(CompartmentedRectangle.State.Default);
     }
 
     private bool IsRectTransformInsideSreen(RectTransform rectTransform)
@@ -41,10 +41,10 @@ public class MouseDragBehaviour : MonoBehaviour, IDragHandler, IBeginDragHandler
         Vector3[] corners = new Vector3[4];
         rectTransform.GetWorldCorners(corners);
         int visibleCorners = 0;
-        Rect rect = new Rect(0,0,Screen.width, Screen.height);
+        Rect rect = new Rect(0, 0, Screen.width, Screen.height);
         foreach (Vector3 corner in corners)
         {
-            if(rect.Contains(corner))
+            if (rect.Contains(corner))
             {
                 visibleCorners++;
             }
@@ -55,5 +55,4 @@ public class MouseDragBehaviour : MonoBehaviour, IDragHandler, IBeginDragHandler
         }
         return isInside;
     }
-
 }

--- a/domain-model-assistant/Assets/Components/Scripts/Position.cs
+++ b/domain-model-assistant/Assets/Components/Scripts/Position.cs
@@ -3,10 +3,15 @@ using System.Collections.Generic;
 using UnityEngine;
 
 [System.Serializable]
-public class PositionInfo
+public class Position
 {
     public float xPosition;
     public float yPosition;
+
+    public Position(float positionX, float positionY){
+        this.xPosition = positionX;
+        this.yPosition = positionY;
+    }
 }
 
 public class AddJsonClass

--- a/domain-model-assistant/Assets/Components/Scripts/Position.cs.meta
+++ b/domain-model-assistant/Assets/Components/Scripts/Position.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: eace4c5eead1bd44daad4a9b4fe54df9
+guid: 2ca3b32466f895142ac51dc9ecb27d11
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/mockserver.js
+++ b/mockserver.js
@@ -144,7 +144,7 @@ app.post('/classdiagram/MULTIPLE_CLASSES/class', (req, res) => {
   const yPos = req.body.y;
 
   const allClassIds = classDiagram.classes.map(c => c._id);
-  const newClassId = (parseInt(allClassIds[allClassIds.length-1])+1).toString();
+  const newClassId = (parseInt(allClassIds[allClassIds.length - 1]) + 1).toString();
 
   classDiagram.classes.push({
     "eClass": "http://cs.mcgill.ca/sel/cdm/1.0#//Class",
@@ -174,14 +174,20 @@ app.post('/classdiagram/MULTIPLE_CLASSES/class', (req, res) => {
 app.put('/classdiagram/MULTIPLE_CLASSES/:classId/position', (req, res) => {
   const classId = req.params.classId;
   var values = classDiagram.layout.containers[0].value/*s*/; // TODO Change to "values" later
+  // retrieve name of class with updated position
+  const allClassIds = classDiagram.classes.map(c => c._id);
+  var classIndex = allClassIds.indexOf(classId);
+  var className = classDiagram.classes[classIndex].name;
+  //update position details
   const allLayoutIds = values.map(c => c.key);
   var index = allLayoutIds.indexOf(classId);
-  classDiagram.layout.containers[0].value[index].value.x = req.body.xPosition;
-  classDiagram.layout.containers[0].value[index].value.y = req.body.yPosition;
-  console.log(">>> Updated classDiagram position = x: " + classDiagram.layout.containers[0].value[index].value.x
-    + "y:" + classDiagram.layout.containers[0].value[index].value.y);
+  var value = classDiagram.layout.containers[0].value[index].value;
+  value.x = req.body.xPosition;
+  value.y = req.body.yPosition;
+  console.log(`>>> Updated ${className} position = x: ${value.x}, y: ${value.y}`);
   res.sendStatus(SUCCESS);
 });
+
 // Delete class
 app.delete('/classdiagram/MULTIPLE_CLASSES/class/:class_id', (req, res) => {
   const classId = req.params.class_id;


### PR DESCRIPTION
1. Added content size fitter component to text box prefab. This ensures that the textbox width is only adjusted depending on the length of the input text thus allowing the class to be dragged from anywhere that is not a text.
2. Addressed some code smells from @YounesB-McGill review.